### PR TITLE
Add summary of right and wrong answers

### DIFF
--- a/templates/vocab_game.html
+++ b/templates/vocab_game.html
@@ -57,6 +57,33 @@
                 <button type="submit" class="reset-button" id="reset-button">Reset Score and Start Over <div class="spinner"></div></button>
             </form>
         {% endif %}
+        
+        <!-- Summary Section -->
+        {% if summary %}
+            <div class="summary-container">
+                <h2>Session Summary</h2>
+                <table class="summary-table">
+                    <thead>
+                        <tr>
+                            <th>Word</th>
+                            <th>Your Answer</th>
+                            <th>Correct Answer</th>
+                            <th>Status</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for entry in summary %}
+                            <tr>
+                                <td>{{ entry.word }}</td>
+                                <td>{{ entry.user_answer }}</td>
+                                <td>{{ entry.correct_answer }}</td>
+                                <td>{{ 'Correct' if entry.status == 'correct' else 'Incorrect' }}</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% endif %}
     </div>
     <script>
         function disableButton(form) {

--- a/vocab_game.py
+++ b/vocab_game.py
@@ -208,6 +208,7 @@ def reset_score():
     session.clear()
     clear_session_files()
     session['score'] = {'correct': 0, 'incorrect': 0}
+    session['summary'] = []
     return redirect(url_for('vocab_game_blueprint.vocab_game'))
 
 
@@ -217,6 +218,8 @@ def reset_score():
 def vocab_game():
     if 'score' not in session:
         session['score'] = {'correct': 0, 'incorrect': 0}
+    if 'summary' not in session:
+        session['summary'] = []
 
     if request.method == 'POST':
         # Retrieve data from the session
@@ -245,6 +248,14 @@ def vocab_game():
             answer_status = "incorrect"
             session['score']['incorrect'] += 1
 
+        # Store the question, user's answer, and correct answer in the session summary
+        session['summary'].append({
+            'word': word,
+            'user_answer': user_answer,
+            'correct_answer': correct_answer,
+            'status': answer_status
+        })
+
         # Mark the session as modified to ensure changes are saved
         session.modified = True
         
@@ -260,7 +271,8 @@ def vocab_game():
             correct_answer=correct_answer,
             answer_status=answer_status,
             score=session['score'],
-            show_next_question=True
+            show_next_question=True,
+            summary=session['summary']
         )
     else:
         # GET request: Initialize new question
@@ -278,7 +290,8 @@ def vocab_game():
                 result='Congratulations! You have learned all the words.',
                 answer_status='',
                 score=session['score'],
-                show_next_question=False
+                show_next_question=False,
+                summary=session['summary']
             )
 
         word = random.choice(unlearned_words)
@@ -301,5 +314,6 @@ def vocab_game():
             result="",
             answer_status="",
             score=session['score'],
-            show_next_question=False
+            show_next_question=False,
+            summary=session['summary']
         )


### PR DESCRIPTION
Add summary of right and wrong answers from the start to the end of the session in the vocab game.

* Modify `vocab_game.py` to store each question, user's answer, and correct answer in the session.
* Add logic in `vocab_game.py` to include the summary of right and wrong answers at the end of the session.
* Update `templates/vocab_game.html` to display a summary of all questions, user answers, and correct answers at the end of the session.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JagadeesanBabu/loki-vocab/pull/3?shareId=ccbda106-a7f4-413b-89cd-e286e3d5e5e6).