### PR TITLE
Add summary of right and wrong answers

### DIFF
--- a/routes/vocab_route.py
+++ b/routes/vocab_route.py
@@ -1,10 +1,9 @@
-
 import datetime
 from flask import Blueprint, render_template, session, redirect, url_for, request
 from flask_login import login_required
 from database.db import db
 from database.models import WordData, WordCount
-from services.vocab_service import reset_score, get_next_question, check_answer
+from services.vocab_service import reset_score, get_next_question, check_answer, get_summary
 from services.google_sheet_service import GoogleSheetsService
 from config import Config
 
@@ -141,3 +140,9 @@ def vocab_game():
             score=session['score'],
             show_next_question=False
         )
+
+@vocab_game_blueprint.route('/summary', methods=['GET'])
+@login_required
+def summary():
+    summary_data = get_summary()
+    return render_template('summary.html', summary=summary_data)

--- a/services/vocab_service.py
+++ b/services/vocab_service.py
@@ -76,6 +76,14 @@ def check_answer(user_answer, word, correct_answer, threshold=0.9):
         result_message = f"Incorrect. The correct meaning of '{word}' is '{correct_answer}'."
         answer_status = "incorrect"
         WordCount.increment_incorrect_count(word)
+        # Store the incorrect answer details to summarize in the summary page.
+        if 'incorrect_answers' not in session:
+            session['incorrect_answers'] = []
+        session['incorrect_answers'].append({
+            'word': word,
+            'user_answer': user_answer,
+            'correct_answer': correct_answer
+        })
 
     return {
         'result_message': result_message,
@@ -92,5 +100,6 @@ def get_summary():
     return {
         'correct_answers': correct_answers,
         'incorrect_answers': incorrect_answers,
-        'total_answers': total_answers
+        'total_answers': total_answers,
+        'incorrect_answer_details': session.get('incorrect_answers', [])
     }

--- a/services/vocab_service.py
+++ b/services/vocab_service.py
@@ -77,6 +77,15 @@ def check_answer(user_answer, word, correct_answer, threshold=0.9):
         answer_status = "incorrect"
         WordCount.increment_incorrect_count(word)
 
+        # Store incorrect answer details in session
+        if 'incorrect_answers' not in session:
+            session['incorrect_answers'] = []
+        session['incorrect_answers'].append({
+            'word': word,
+            'user_answer': user_answer,
+            'correct_answer': correct_answer
+        })
+
     return {
         'result_message': result_message,
         'correct_answer': correct_answer,
@@ -89,8 +98,10 @@ def get_summary():
     correct_answers = session['score']['correct']
     incorrect_answers = session['score']['incorrect']
     total_answers = correct_answers + incorrect_answers
+    incorrect_answer_details = session.get('incorrect_answers', [])
     return {
         'correct_answers': correct_answers,
         'incorrect_answers': incorrect_answers,
-        'total_answers': total_answers
+        'total_answers': total_answers,
+        'incorrect_answer_details': incorrect_answer_details
     }

--- a/services/vocab_service.py
+++ b/services/vocab_service.py
@@ -77,15 +77,6 @@ def check_answer(user_answer, word, correct_answer, threshold=0.9):
         answer_status = "incorrect"
         WordCount.increment_incorrect_count(word)
 
-        # Store incorrect answer details in session
-        if 'incorrect_answers' not in session:
-            session['incorrect_answers'] = []
-        session['incorrect_answers'].append({
-            'word': word,
-            'user_answer': user_answer,
-            'correct_answer': correct_answer
-        })
-
     return {
         'result_message': result_message,
         'correct_answer': correct_answer,
@@ -98,10 +89,8 @@ def get_summary():
     correct_answers = session['score']['correct']
     incorrect_answers = session['score']['incorrect']
     total_answers = correct_answers + incorrect_answers
-    incorrect_answer_details = session.get('incorrect_answers', [])
     return {
         'correct_answers': correct_answers,
         'incorrect_answers': incorrect_answers,
-        'total_answers': total_answers,
-        'incorrect_answer_details': incorrect_answer_details
+        'total_answers': total_answers
     }

--- a/services/vocab_service.py
+++ b/services/vocab_service.py
@@ -77,16 +77,20 @@ def check_answer(user_answer, word, correct_answer, threshold=0.9):
         answer_status = "incorrect"
         WordCount.increment_incorrect_count(word)
 
-
-
-    
-    
-
-    
-
     return {
         'result_message': result_message,
         'correct_answer': correct_answer,
         'answer_status': answer_status,
         'updated_score': session['score']
+    }
+
+def get_summary():
+    """Aggregates the summary of right and wrong answers."""
+    correct_answers = session['score']['correct']
+    incorrect_answers = session['score']['incorrect']
+    total_answers = correct_answers + incorrect_answers
+    return {
+        'correct_answers': correct_answers,
+        'incorrect_answers': incorrect_answers,
+        'total_answers': total_answers
     }

--- a/static/dashboard.css
+++ b/static/dashboard.css
@@ -1,14 +1,18 @@
+/* General Styles */
 body {
     font-family: Arial, sans-serif;
     margin: 20px;
     background-color: #f4f4f4;
+    color: #333;
 }
 
 h1 {
     text-align: center;
     color: #333;
+    margin-bottom: 20px;
 }
 
+/* Summary Section */
 .summary {
     margin-bottom: 30px;
     text-align: center;
@@ -18,44 +22,74 @@ h1 {
     font-size: 18px;
 }
 
-.stats {
-    margin-bottom: 40px;
-}
-
-.stats h2 {
-    text-align: center;
-    color: #333;
-}
-
-table {
-    width: 80%;
-    margin: 0 auto 30px auto;
-    border-collapse: collapse;
-    background-color: #fff;
-}
-
-table, th, td {
-    border: 1px solid #ddd;
-}
-
-th, td {
-    padding: 12px;
+/* Score Container */
+.score-container {
+    display: flex;
+    justify-content: center;
+    gap: 20px;
+    margin-bottom: 30px;
     text-align: left;
 }
 
-th {
-    background-color: #f2f2f2;
+.score-container p {
+    font-size: 16px;
+    background-color: #ffffff;
+    padding: 10px 15px;
+    border-radius: 5px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-.charts {
+/* Incorrect Answers Section */
+.incorrect-answers {
+    margin: 20px auto;
     width: 80%;
-    margin: 0 auto;
+    background-color: #ffffff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
 }
 
-.charts h2 {
-    text-align: center;
-    color: #333;
+.incorrect-answers h2 {
+    font-size: 1.5em;
+    color: #d32f2f;
+    margin-bottom: 20px;
+    border-bottom: 2px solid #d32f2f;
+    padding-bottom: 5px;
 }
+
+.incorrect-answers ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.incorrect-answers li {
+    margin-bottom: 20px;
+    padding: 15px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    background-color: #f9f9f9;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+/* Styling for User and Correct Answers */
+.incorrect-answers .your-answer {
+    color: #d32f2f;
+    font-style: italic;
+}
+
+.incorrect-answers .correct-answer {
+    color: #388e3c;
+    font-weight: bold;
+    background-color: #f1f8f1;
+    border-left: 4px solid #388e3c;
+    padding: 10px;
+    margin-top: 10px;
+    display: block;
+    border-radius: 4px;
+}
+
+/* Navigation Links */
 .header {
     display: flex;
     justify-content: flex-end;
@@ -71,6 +105,20 @@ th {
     border-radius: 5px;
     font-weight: 600;
     transition: background-color 0.3s ease;
+    display: flex;
+    align-items: center;
+}
+
+.summary-link {
+    text-decoration: none;
+    color: #fff;
+    background-color: #007bff;
+    padding: 10px 20px;
+    border-radius: 5px;
+    font-weight: 600;
+    transition: background-color 0.3s ease;
+    display: flex;
+    align-items: center;
 }
 
 .quiz-link:hover {
@@ -96,4 +144,25 @@ th {
 @keyframes spin {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
+}
+
+/* Table (if needed) */
+table {
+    width: 80%;
+    margin: 20px auto;
+    border-collapse: collapse;
+    background-color: #fff;
+}
+
+table, th, td {
+    border: 1px solid #ddd;
+}
+
+th, td {
+    padding: 12px;
+    text-align: left;
+}
+
+th {
+    background-color: #f2f2f2;
 }

--- a/static/summary.css
+++ b/static/summary.css
@@ -1,0 +1,99 @@
+/* Global styling */
+body {
+    font-family: 'Source Sans Pro', sans-serif;
+    background-color: #f9f9f9;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    margin: 0;
+}
+
+/* Summary container styling */
+.game-container {
+    background: #ffffff;
+    border-radius: 12px;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.15);
+    padding: 25px;
+    width: 90%;
+    max-width: 600px;
+}
+
+/* Header styling */
+.header {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    margin-bottom: 20px;
+}
+
+.quiz-link {
+    text-decoration: none;
+    color: #fff;
+    background-color: #007bff;
+    padding: 10px 20px;
+    border-radius: 5px;
+    font-weight: 600;
+    transition: background-color 0.3s ease;
+}
+
+.quiz-link:hover {
+    background-color: #0056b3;
+}
+
+.quiz-link .spinner {
+    display: none;
+    margin-left: 10px;
+    border: 2px solid #fff;
+    border-top: 2px solid #007bff;
+    border-radius: 50%;
+    width: 12px;
+    height: 12px;
+    animation: spin 0.6s linear infinite;
+}
+
+.quiz-link.loading {
+    pointer-events: none;
+    opacity: 0.7;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+/* Title styling */
+h1 {
+    color: #333;
+    font-weight: 600;
+    font-size: 1.8em;
+    margin: 10px 0 20px;
+    text-align: center;
+}
+
+/* Score container styling */
+.score-container {
+    text-align: left;
+    font-size: 1em;
+    color: #444;
+    margin-bottom: 15px;
+}
+
+.score-container p {
+    margin: 5px 0;
+}
+
+.score-total {
+    color: #007bff;
+    font-weight: 600;
+}
+
+.score-correct {
+    color: #28a745;
+    font-weight: 600;
+}
+
+.score-incorrect {
+    color: #dc3545;
+    font-weight: 600;
+}

--- a/static/summary.css
+++ b/static/summary.css
@@ -76,7 +76,14 @@ h1 {
     text-align: left;
     font-size: 1em;
     color: #444;
-    margin-bottom: 15px;
+    margin-bottom: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    background: #f9f9f9;
+    padding: 15px;
+    border-radius: 8px;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
 }
 
 .score-container p {
@@ -96,4 +103,79 @@ h1 {
 .score-incorrect {
     color: #dc3545;
     font-weight: 600;
+}
+
+/* Incorrect answers section */
+.incorrect-answers {
+    margin: 20px 0;
+    background-color: #ffffff;
+    padding: 20px;
+    border-radius: 12px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+
+.incorrect-answers h2 {
+    font-size: 1.5em;
+    color: #d32f2f;
+    margin-bottom: 15px;
+    border-bottom: 2px solid #d32f2f;
+    padding-bottom: 5px;
+}
+
+.incorrect-answers ul {
+    list-style-type: none;
+    padding: 0;
+}
+
+.incorrect-answers li {
+    margin-bottom: 15px;
+    padding: 15px;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    background-color: #f9f9f9;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.incorrect-answers li strong {
+    font-weight: bold;
+    color: #555;
+}
+
+.incorrect-answers .your-answer {
+    color: #dc3545;
+    font-style: italic;
+}
+
+.incorrect-answers .correct-answer {
+    color: #28a745;
+    font-weight: bold;
+    background-color: #e8f5e9;
+    border-left: 4px solid #28a745;
+    padding: 10px;
+    margin-top: 10px;
+    display: block;
+    border-radius: 4px;
+}
+
+/* Responsive design */
+@media (max-width: 768px) {
+    .game-container {
+        padding: 20px;
+    }
+
+    .score-container {
+        font-size: 0.9em;
+    }
+
+    .incorrect-answers {
+        padding: 15px;
+    }
+
+    .incorrect-answers h2 {
+        font-size: 1.2em;
+    }
+
+    .incorrect-answers li {
+        font-size: 0.9em;
+    }
 }

--- a/static/vocab_game.css
+++ b/static/vocab_game.css
@@ -27,7 +27,7 @@ body {
     margin-bottom: 20px;
 }
 
-.logout-link, .dashboard-link {
+.logout-link, .dashboard-link, .summary-link{
     text-decoration: none;
     color: #fff;
     background-color: #007bff;
@@ -37,7 +37,7 @@ body {
     transition: background-color 0.3s ease;
 }
 
-.logout-link:hover, .dashboard-link:hover {
+.logout-link:hover, .dashboard-link:hover, .summary-link:hover {
     background-color: #0056b3;
 }
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -12,6 +12,7 @@
         <h1>Loke Progress Dashboard</h1>
         <div class="header">
             <a href="{{ url_for('vocab_game_blueprint.vocab_game') }}" class="quiz-link" id="quiz-link">Go2Quiz <div class="spinner"></div></a>
+            <a href="{{ url_for('vocab_game_blueprint.summary') }}" class="summary-link" id="summary-link">Summary <div class="spinner"></div></a>
         </div>
         <div class="Daily-charts">
             <h2>Loke Progress Dashboard Last Month</h2>
@@ -81,6 +82,11 @@
                 const dailyCountsChart = new Chart(ctx, config);
                
                 document.getElementById('quiz-link').addEventListener('click', function(event) {
+                var link = event.currentTarget;
+                link.classList.add('loading');
+                link.querySelector('.spinner').style.display = 'inline-block';
+            });
+                document.getElementById('summary-link').addEventListener('click', function(event) {
                 var link = event.currentTarget;
                 link.classList.add('loading');
                 link.querySelector('.spinner').style.display = 'inline-block';

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -17,6 +17,18 @@
         <div class="header">
             <a href="{{ url_for('vocab_game_blueprint.vocab_game') }}" class="quiz-link" id="quiz-link">Back to Quiz <div class="spinner"></div></a>
         </div>
+        <div class="incorrect-answers">
+            <h2>Incorrect Answers</h2>
+            <ul>
+                {% for answer in summary.incorrect_answer_details %}
+                    <li>
+                        <strong>Word:</strong> {{ answer.word }}<br>
+                        <span class="your-answer"><strong>Your Answer:</strong> {{ answer.user_answer }}</span><br>
+                        <span class="correct-answer"><strong>Correct Answer:</strong> {{ answer.correct_answer }}</span>
+                    </li>
+                {% endfor %}
+            </ul>
+        </div>
     </div>
     <script>
         document.getElementById('quiz-link').addEventListener('click', function(event) {

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -14,6 +14,18 @@
             <p><strong>Correct Answers:</strong> <span class="score-correct">{{ summary.correct_answers }}</span></p>
             <p><strong>Incorrect Answers:</strong> <span class="score-incorrect">{{ summary.incorrect_answers }}</span></p>
         </div>
+        <div class="incorrect-answers">
+            <h2>Incorrect Answers</h2>
+            <ul>
+                {% for answer in summary.incorrect_answer_details %}
+                    <li>
+                        <strong>Word:</strong> {{ answer.word }}<br>
+                        <strong>Your Answer:</strong> {{ answer.user_answer }}<br>
+                        <strong>Correct Answer:</strong> {{ answer.correct_answer }}
+                    </li>
+                {% endfor %}
+            </ul>
+        </div>
         <div class="header">
             <a href="{{ url_for('vocab_game_blueprint.vocab_game') }}" class="quiz-link" id="quiz-link">Back to Quiz <div class="spinner"></div></a>
         </div>

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Summary</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='vocab_game.css') }}">
+</head>
+<body>
+    <div class="game-container">
+        <h1>Session Summary</h1>
+        <div class="score-container">
+            <p><strong>Total Answers:</strong> <span class="score-total">{{ summary.total_answers }}</span></p>
+            <p><strong>Correct Answers:</strong> <span class="score-correct">{{ summary.correct_answers }}</span></p>
+            <p><strong>Incorrect Answers:</strong> <span class="score-incorrect">{{ summary.incorrect_answers }}</span></p>
+        </div>
+        <div class="header">
+            <a href="{{ url_for('vocab_game_blueprint.vocab_game') }}" class="quiz-link" id="quiz-link">Back to Quiz <div class="spinner"></div></a>
+        </div>
+    </div>
+    <script>
+        document.getElementById('quiz-link').addEventListener('click', function(event) {
+            var link = event.currentTarget;
+            link.classList.add('loading');
+            link.querySelector('.spinner').style.display = 'inline-block';
+        });
+    </script>
+</body>
+</html>

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Summary</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='vocab_game.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='summary.css') }}">
 </head>
 <body>
     <div class="game-container">
@@ -13,18 +13,6 @@
             <p><strong>Total Answers:</strong> <span class="score-total">{{ summary.total_answers }}</span></p>
             <p><strong>Correct Answers:</strong> <span class="score-correct">{{ summary.correct_answers }}</span></p>
             <p><strong>Incorrect Answers:</strong> <span class="score-incorrect">{{ summary.incorrect_answers }}</span></p>
-        </div>
-        <div class="incorrect-answers">
-            <h2>Incorrect Answers</h2>
-            <ul>
-                {% for answer in summary.incorrect_answer_details %}
-                    <li>
-                        <strong>Word:</strong> {{ answer.word }}<br>
-                        <strong>Your Answer:</strong> {{ answer.user_answer }}<br>
-                        <strong>Correct Answer:</strong> {{ answer.correct_answer }}
-                    </li>
-                {% endfor %}
-            </ul>
         </div>
         <div class="header">
             <a href="{{ url_for('vocab_game_blueprint.vocab_game') }}" class="quiz-link" id="quiz-link">Back to Quiz <div class="spinner"></div></a>

--- a/templates/vocab_game.html
+++ b/templates/vocab_game.html
@@ -16,6 +16,7 @@
         <div class="header">
             <a href="{{ url_for('login_blueprint.logout') }}" class="logout-link">Logout</a>
             <a href="{{ url_for('vocab_game_blueprint.dashboard') }}" id="dashboard-link" class="dashboard-link">Dashboard <div class="spinner"></div></a>
+            <a href="{{ url_for('vocab_game_blueprint.summary') }}" id="summary-link" class="summary-link">Summary <div class="spinner"></div></a>
         </div>
         
         <div class="score-container">
@@ -60,6 +61,11 @@
             button.classList.add('loading');
         }
         document.getElementById('dashboard-link').addEventListener('click', function(event) {
+            var link = event.currentTarget;
+            link.classList.add('loading');
+            link.querySelector('.spinner').style.display = 'inline-block';
+        });
+        document.getElementById('summary-link').addEventListener('click', function(event) {
             var link = event.currentTarget;
             link.classList.add('loading');
             link.querySelector('.spinner').style.display = 'inline-block';


### PR DESCRIPTION
Add functionality to display a summary of right and wrong answers from the start to the end of the session.

* **routes/vocab_route.py**
  - Import `get_summary` from `services/vocab_service.py`
  - Add a new route `/summary` to display the summary of right and wrong answers

* **services/vocab_service.py**
  - Add a new function `get_summary` to aggregate the summary of right and wrong answers

* **templates/summary.html**
  - Create a new template to display the summary of right and wrong answers

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JagadeesanBabu/loki-vocab/pull/4?shareId=9e9abef3-ac6a-4f4a-8dc9-c5e921a88524).